### PR TITLE
Adding diagnostics support in cosmos ycsb benchmarking tool

### DIFF
--- a/cosmos/azuredeploy.json
+++ b/cosmos/azuredeploy.json
@@ -152,7 +152,7 @@
         "networkInterfaceName": "[concat(parameters('projectName'), '-nic')]",
         "networkSecurityGroupName": "[concat(parameters('projectName'), '-nsg')]",
         "deploymentName": "[deployment().name]",
-		"diagnosticsLatencyThresholdInMS": "[parameters('diagnosticsLatencyThresholdInMS')]"
+        "diagnosticsLatencyThresholdInMS": "[parameters('diagnosticsLatencyThresholdInMS')]"
 		
     },
     "resources": [

--- a/cosmos/azuredeploy.json
+++ b/cosmos/azuredeploy.json
@@ -151,9 +151,7 @@
         "publicIPAddressName": "[concat(parameters('projectName'), '-ip')]",
         "networkInterfaceName": "[concat(parameters('projectName'), '-nic')]",
         "networkSecurityGroupName": "[concat(parameters('projectName'), '-nsg')]",
-        "deploymentName": "[deployment().name]",
-        "diagnosticsLatencyThresholdInMS": "[parameters('diagnosticsLatencyThresholdInMS')]"
-		
+        "deploymentName": "[deployment().name]"		
     },
     "resources": [
         {
@@ -363,7 +361,7 @@
                 "settings": {
                 },
                 "protectedSettings": {
-                    "commandToExecute": "[concat('YCSB_GIT_REPO_URL=',parameters('ycsbGitRepositoryURL'),' ','DEPLOYMENT_NAME=',variables('deploymentName'),' ','GUID=',parameters('guidValue'),' ','YCSB_GIT_BRANCH_NAME=',parameters('ycsbGitBranchName'),' ','TARGET_OPERATIONS_PER_SECOND=',parameters('targetOperationsPerSecond'),' ','THREAD_COUNT=',parameters('threads'),' ','YCSB_OPERATION=',parameters('ycsbOperation'),' ','YCSB_OPERATION_COUNT=',parameters('ycsbOperationCount'), ' ','WORKLOAD_TYPE=',parameters('workloadType'),' ','VM_NAME=',variables('vmName'),copyIndex(1), ' ','RESULT_STORAGE_CONNECTION_STRING=','\"',parameters('resultsStorageConnectionString'),'\"',' ','COSMOS_URI=',parameters('cosmosURI'), ' ','COSMOS_KEY=',parameters('cosmosKey'), ' ','VM_COUNT=',parameters('vmCount'), ' ','DIAGNOSTICS_LATENCY_THRESHOLD_IN_MS=',variables('diagnosticsLatencyThresholdInMS'), ' ','ITEM_COUNT_FOR_WRITE=',parameters('itemCountForWriteOps'), ' ','MACHINE_INDEX=',copyIndex(1), ' ', 'bash ',parameters('vmScriptExtensionScriptName'))]",
+                    "commandToExecute": "[concat('YCSB_GIT_REPO_URL=',parameters('ycsbGitRepositoryURL'),' ','DEPLOYMENT_NAME=',variables('deploymentName'),' ','GUID=',parameters('guidValue'),' ','YCSB_GIT_BRANCH_NAME=',parameters('ycsbGitBranchName'),' ','TARGET_OPERATIONS_PER_SECOND=',parameters('targetOperationsPerSecond'),' ','THREAD_COUNT=',parameters('threads'),' ','YCSB_OPERATION=',parameters('ycsbOperation'),' ','YCSB_OPERATION_COUNT=',parameters('ycsbOperationCount'), ' ','WORKLOAD_TYPE=',parameters('workloadType'),' ','VM_NAME=',variables('vmName'),copyIndex(1), ' ','RESULT_STORAGE_CONNECTION_STRING=','\"',parameters('resultsStorageConnectionString'),'\"',' ','COSMOS_URI=',parameters('cosmosURI'), ' ','COSMOS_KEY=',parameters('cosmosKey'), ' ','VM_COUNT=',parameters('vmCount'), ' ','DIAGNOSTICS_LATENCY_THRESHOLD_IN_MS=',parameters('diagnosticsLatencyThresholdInMS'), ' ','ITEM_COUNT_FOR_WRITE=',parameters('itemCountForWriteOps'), ' ','MACHINE_INDEX=',copyIndex(1), ' ', 'bash ',parameters('vmScriptExtensionScriptName'))]",
                     "fileUris": [ "[concat(parameters('vmScriptExtensionScriptURL'))]" ]
                 }
             },

--- a/cosmos/azuredeploy.json
+++ b/cosmos/azuredeploy.json
@@ -134,9 +134,13 @@
                 "description": "Specifies the cloud-init file url"
             }
         },
-            "guidValue": {
+        "guidValue": {
             "type": "string",
             "defaultValue": "[newGuid()]"
+        },
+		"diagnosticsLatencyThresholdInMS": {
+            "type": "int",
+            "defaultValue": -1
         }
     },
     "variables": {
@@ -147,7 +151,9 @@
         "publicIPAddressName": "[concat(parameters('projectName'), '-ip')]",
         "networkInterfaceName": "[concat(parameters('projectName'), '-nic')]",
         "networkSecurityGroupName": "[concat(parameters('projectName'), '-nsg')]",
-        "deploymentName": "[deployment().name]"
+        "deploymentName": "[deployment().name]",
+		"diagnosticsLatencyThresholdInMS": "[parameters('diagnosticsLatencyThresholdInMS')]"
+		
     },
     "resources": [
         {
@@ -357,7 +363,7 @@
                 "settings": {
                 },
                 "protectedSettings": {
-                    "commandToExecute": "[concat('YCSB_GIT_REPO_URL=',parameters('ycsbGitRepositoryURL'),' ','DEPLOYMENT_NAME=',variables('deploymentName'),' ','GUID=',parameters('guidValue'),' ','YCSB_GIT_BRANCH_NAME=',parameters('ycsbGitBranchName'),' ','TARGET_OPERATIONS_PER_SECOND=',parameters('targetOperationsPerSecond'),' ','THREAD_COUNT=',parameters('threads'),' ','YCSB_OPERATION=',parameters('ycsbOperation'),' ','YCSB_OPERATION_COUNT=',parameters('ycsbOperationCount'), ' ','WORKLOAD_TYPE=',parameters('workloadType'),' ','VM_NAME=',variables('vmName'),copyIndex(1), ' ','RESULT_STORAGE_CONNECTION_STRING=','\"',parameters('resultsStorageConnectionString'),'\"',' ','COSMOS_URI=',parameters('cosmosURI'), ' ','COSMOS_KEY=',parameters('cosmosKey'), ' ','VM_COUNT=',parameters('vmCount'), ' ','ITEM_COUNT_FOR_WRITE=',parameters('itemCountForWriteOps'), ' ','MACHINE_INDEX=',copyIndex(1), ' ', 'bash ',parameters('vmScriptExtensionScriptName'))]",
+                    "commandToExecute": "[concat('YCSB_GIT_REPO_URL=',parameters('ycsbGitRepositoryURL'),' ','DEPLOYMENT_NAME=',variables('deploymentName'),' ','GUID=',parameters('guidValue'),' ','YCSB_GIT_BRANCH_NAME=',parameters('ycsbGitBranchName'),' ','TARGET_OPERATIONS_PER_SECOND=',parameters('targetOperationsPerSecond'),' ','THREAD_COUNT=',parameters('threads'),' ','YCSB_OPERATION=',parameters('ycsbOperation'),' ','YCSB_OPERATION_COUNT=',parameters('ycsbOperationCount'), ' ','WORKLOAD_TYPE=',parameters('workloadType'),' ','VM_NAME=',variables('vmName'),copyIndex(1), ' ','RESULT_STORAGE_CONNECTION_STRING=','\"',parameters('resultsStorageConnectionString'),'\"',' ','COSMOS_URI=',parameters('cosmosURI'), ' ','COSMOS_KEY=',parameters('cosmosKey'), ' ','VM_COUNT=',parameters('vmCount'), ' ','DIAGNOSTICS_LATENCY_THRESHOLD_IN_MS=',variables('diagnosticsLatencyThresholdInMS'), ' ','ITEM_COUNT_FOR_WRITE=',parameters('itemCountForWriteOps'), ' ','MACHINE_INDEX=',copyIndex(1), ' ', 'bash ',parameters('vmScriptExtensionScriptName'))]",
                     "fileUris": [ "[concat(parameters('vmScriptExtensionScriptURL'))]" ]
                 }
             },

--- a/execute.sh
+++ b/execute.sh
@@ -126,7 +126,7 @@ if [ "$YCSB_OPERATION" = "run" ]; then
   # Clearing log file from above load operation
   sudo rm -f /tmp/ycsb.log
   sudo rm -f "/home/benchmarking/$VM_NAME-ycsb-load.txt"
-  uri=$COSMOS_URI primaryKey=$COSMOS_KEY workload_type=$WORKLOAD_TYPE ycsb_operation=$YCSB_OPERATION recordcount=$totalrecordcount operationcount=$YCSB_OPERATION_COUNT threads=$THREAD_COUNT target=$TARGET_OPERATIONS_PER_SECOND sh run.sh
+  uri=$COSMOS_URI primaryKey=$COSMOS_KEY workload_type=$WORKLOAD_TYPE ycsb_operation=$YCSB_OPERATION recordcount=$totalrecordcount operationcount=$YCSB_OPERATION_COUNT threads=$THREAD_COUNT target=$TARGET_OPERATIONS_PER_SECOND diagnosticsLatencyThresholdInMS=$DIAGNOSTICS_LATENCY_THRESHOLD_IN_MS sh run.sh
 fi
 
 #Copy YCSB log to storage account

--- a/execute.sh
+++ b/execute.sh
@@ -109,7 +109,7 @@ fi
 
 ##Load operation for YCSB tests
 echo "########## Load operation for YCSB tests ###########"
-uri=$COSMOS_URI primaryKey=$COSMOS_KEY workload_type=$WORKLOAD_TYPE ycsb_operation="load" recordcount=$recordcount insertstart=$insertstart insertcount=$ITEM_COUNT_FOR_WRITE threads=$THREAD_COUNT target=$TARGET_OPERATIONS_PER_SECOND sh run.sh
+uri=$COSMOS_URI primaryKey=$COSMOS_KEY workload_type=$WORKLOAD_TYPE ycsb_operation="load" recordcount=$recordcount insertstart=$insertstart insertcount=$ITEM_COUNT_FOR_WRITE threads=$THREAD_COUNT target=$TARGET_OPERATIONS_PER_SECOND diagnosticsLatencyThresholdInMS=$DIAGNOSTICS_LATENCY_THRESHOLD_IN_MS sh run.sh
 
 #Execute YCSB test
 if [ "$YCSB_OPERATION" = "run" ]; then


### PR DESCRIPTION
Parameter diagnosticsLatencyThresholdInMS is added in base azuredeploy.json file , with default -1 which means no diagnostics.
This is basically for internal investigation purpose , that's why avoided in the recipes.
Supported changes in ycsb already checked in into branch simplynaveen20/addingDockerScripts with commit https://github.com/simplynaveen20/YCSB/commit/d833186e1ce3c9868b34ca7d8a396fc601237ab2

"diagnosticsLatencyThresholdInMS": {
            "type": "int",
            "defaultValue": -1
        }