### PR TITLE
Redesigning write only ops, added request distribution and insert order config

### DIFF
--- a/cosmos/azuredeploy.json
+++ b/cosmos/azuredeploy.json
@@ -69,29 +69,21 @@
             }
 
         },
-        "ycsbOperation": {
-            "type": "string",
-            "defaultValue": "load",
-            "metadata": {
-                "description": "Specifies the operation"
-            }
-
-        },
         "threads": {
             "type": "int",
-            "defaultValue": 0,
+            "defaultValue": 1,
             "metadata": {
                 "description": "Specifies the threads per client"
             }
         },
         "targetOperationsPerSecond": {
             "type": "int",
-            "defaultValue": 2,
+            "defaultValue": -1,
             "metadata": {
                 "description": "Specifies the maximum number of operations per second"
             }
         },
-        "itemCountForWriteOps": {
+        "ycsbRecordCount": {
             "type": "int",
             "defaultValue": 1
         },
@@ -141,6 +133,55 @@
 		"diagnosticsLatencyThresholdInMS": {
             "type": "int",
             "defaultValue": -1
+        },
+        "readproportion": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Specifies read operation percentage from 0 to 1"
+            }
+        },
+        "updateproportion": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Specifies update operation percentage from 0 to 1"
+            }
+        },
+        "scanproportion": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Specifies scan operation percentage from 0 to 1"
+            }
+        },
+        "insertproportion": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Specifies insert operation percentage from 0 to 1"
+            }
+        },
+        "writeOnlyOperation": {
+            "type": "bool",
+            "defaultValue": false,
+            "metadata": {
+                "description": "Specifies writeOnlyOperation true or false, if true it will override the workload and run 100% write, transaction wont fail on single error which is opposite of load phase"
+            }
+        },
+        "requestdistribution": {
+            "type": "string",
+            "defaultValue": "uniform",
+            "metadata": {
+                "description": "Specifies request distribution"
+            }
+        },
+		"insertorder": {
+            "type": "string",
+            "defaultValue": "hashed",
+            "metadata": {
+                "description": "Specifies insert data in ordered or hashed manner"
+            }
         }
     },
     "variables": {
@@ -361,7 +402,7 @@
                 "settings": {
                 },
                 "protectedSettings": {
-                    "commandToExecute": "[concat('YCSB_GIT_REPO_URL=',parameters('ycsbGitRepositoryURL'),' ','DEPLOYMENT_NAME=',variables('deploymentName'),' ','GUID=',parameters('guidValue'),' ','YCSB_GIT_BRANCH_NAME=',parameters('ycsbGitBranchName'),' ','TARGET_OPERATIONS_PER_SECOND=',parameters('targetOperationsPerSecond'),' ','THREAD_COUNT=',parameters('threads'),' ','YCSB_OPERATION=',parameters('ycsbOperation'),' ','YCSB_OPERATION_COUNT=',parameters('ycsbOperationCount'), ' ','WORKLOAD_TYPE=',parameters('workloadType'),' ','VM_NAME=',variables('vmName'),copyIndex(1), ' ','RESULT_STORAGE_CONNECTION_STRING=','\"',parameters('resultsStorageConnectionString'),'\"',' ','COSMOS_URI=',parameters('cosmosURI'), ' ','COSMOS_KEY=',parameters('cosmosKey'), ' ','VM_COUNT=',parameters('vmCount'), ' ','DIAGNOSTICS_LATENCY_THRESHOLD_IN_MS=',parameters('diagnosticsLatencyThresholdInMS'), ' ','ITEM_COUNT_FOR_WRITE=',parameters('itemCountForWriteOps'), ' ','MACHINE_INDEX=',copyIndex(1), ' ', 'bash ',parameters('vmScriptExtensionScriptName'))]",
+                    "commandToExecute": "[concat('YCSB_GIT_REPO_URL=',parameters('ycsbGitRepositoryURL'),' ','DEPLOYMENT_NAME=',variables('deploymentName'),' ','GUID=',parameters('guidValue'),' ','YCSB_GIT_BRANCH_NAME=',parameters('ycsbGitBranchName'),' ','TARGET_OPERATIONS_PER_SECOND=',parameters('targetOperationsPerSecond'),' ','THREAD_COUNT=',parameters('threads'),' ','YCSB_OPERATION_COUNT=',parameters('ycsbOperationCount'), ' ','WORKLOAD_TYPE=',parameters('workloadType'),' ','VM_NAME=',variables('vmName'),copyIndex(1), ' ','RESULT_STORAGE_CONNECTION_STRING=','\"',parameters('resultsStorageConnectionString'),'\"',' ','COSMOS_URI=',parameters('cosmosURI'), ' ','COSMOS_KEY=',parameters('cosmosKey'), ' ','VM_COUNT=',parameters('vmCount'), ' ','DIAGNOSTICS_LATENCY_THRESHOLD_IN_MS=',parameters('diagnosticsLatencyThresholdInMS'), ' ','YCSB_RECORD_COUNT=',parameters('ycsbRecordCount'), ' ','WRITE_ONLY_OPERATION=',parameters('writeOnlyOperation'), ' ','READ_PROPORTION=',parameters('readproportion'), ' ','SCAN_PROPORTION=',parameters('scanproportion'), ' ','UPDATE_PROPORTION=',parameters('updateproportion'), ' ','INSERT_PROPORTION=',parameters('insertproportion'), ' ','REQUEST_DISTRIBUTION=',parameters('requestdistribution'), ' ','INSERT_ORDER=',parameters('insertorder'), ' ','MACHINE_INDEX=',copyIndex(1), ' ', 'bash ',parameters('vmScriptExtensionScriptName'))]",
                     "fileUris": [ "[concat(parameters('vmScriptExtensionScriptURL'))]" ]
                 }
             },

--- a/cosmos/azuredeploy.json
+++ b/cosmos/azuredeploy.json
@@ -176,7 +176,7 @@
                 "description": "Specifies request distribution"
             }
         },
-		"insertorder": {
+        "insertorder": {
             "type": "string",
             "defaultValue": "hashed",
             "metadata": {

--- a/cosmos/parameter.json
+++ b/cosmos/parameter.json
@@ -17,20 +17,28 @@
     "vmCount": {
       "value": 1
     },
-    "itemCountForWriteOps": {
+    "ycsbRecordCount": {
       "value": 1
     },
     "ycsbOperationCount": {
       "value": 1
     },
+	,
     "threads": {
       "value": 1
     },
     "targetOperationsPerSecond": {
       "value": 1
     },
-	"ycsbOperation": {
-      "value": "load"
+    "writeOnlyOperation": {
+      "value": false
+    },
+    "diagnosticsLatencyThresholdInMS": {
+      "value": 15
+    },
+    "insertorder": {
+      "value": "ordered"
     }
   }
 }
+

--- a/cosmos/sql/recipes/1-million-rps-write/azuredeploy.json
+++ b/cosmos/sql/recipes/1-million-rps-write/azuredeploy.json
@@ -91,7 +91,7 @@
                 "description": "Specifies the maximum number of operations per second"
             }
         },
-        "itemCountForWriteOps": {
+        "ycsbRecordCount": {
             "type": "int",
             "defaultValue": 1
         },
@@ -178,17 +178,14 @@
                     "workloadType": {
                         "value": "[parameters('workloadType')]"
                     },
-                    "ycsbOperation": {
-                        "value": "[parameters('ycsbOperation')]"
-                    },
                     "threads": {
                         "value": "[parameters('threads')]"
                     },
                     "targetOperationsPerSecond": {
                         "value": "[parameters('targetOperationsPerSecond')]"
                     },
-                    "itemCountForWriteOps": {
-                        "value": "[parameters('itemCountForWriteOps')]"
+                    "ycsbRecordCount": {
+                        "value": "[parameters('ycsbRecordCount')]"
                     },
                     "ycsbOperationCount": {
                         "value": "[parameters('ycsbOperationCount')]"

--- a/execute.sh
+++ b/execute.sh
@@ -70,7 +70,7 @@ if [ $MACHINE_INDEX -eq 1 ]; then
 
   result_storage_url="${protocol}://${account_name}.blob.core.windows.net/result-${current_time}?${sas}"
 
-  client_start_time=$(date -u -d "5 minutes" '+%Y-%m-%dT%H:%M:%S') # date in ISO 8601 format
+  client_start_time=$(date -u -d "1 minutes" '+%Y-%m-%dT%H:%M:%S') # date in ISO 8601 format
   az storage entity insert --entity PartitionKey="ycsb_sql" RowKey="${GUID}" ClientStartTime=$client_start_time SAS_URL=$result_storage_url JobStatus="Started" NoOfClientsCompleted=0 --table-name "${DEPLOYMENT_NAME}Metadata" --connection-string $RESULT_STORAGE_CONNECTION_STRING
 else
   for i in $(seq 1 5); do
@@ -143,7 +143,7 @@ sudo azcopy copy "/home/benchmarking/$VM_NAME-ycsb.log" "$result_storage_url"
 
 if [ $MACHINE_INDEX -eq 1 ]; then
   echo "Waiting on VM1 for 5 min"
-  sleep 5m
+  sleep 5s
   cd /home/benchmarking
   mkdir "aggregation"
   cd aggregation

--- a/execute.sh
+++ b/execute.sh
@@ -8,6 +8,7 @@ echo "##########YCSB_RECORD_COUNT###########: $YCSB_RECORD_COUNT"
 echo "##########MACHINE_INDEX###########: $MACHINE_INDEX"
 echo "##########YCSB_OPERATION_COUNT###########: $YCSB_OPERATION_COUNT"
 echo "##########VM_COUNT###########: $VM_COUNT"
+echo "##########WRITE_ONLY_OPERATION###########: $WRITE_ONLY_OPERATION"
 
 # The index of the record to start at during the Load
 insertstart=$((YCSB_RECORD_COUNT * (MACHINE_INDEX - 1)))
@@ -130,7 +131,7 @@ else
   sudo rm -f "/home/benchmarking/$VM_NAME-ycsb-load.txt"
   ##execute run phase for YCSB tests
   echo "########## Run operation for YCSB tests ###########"
-  uri=$COSMOS_URI primaryKey=$COSMOS_KEY workload_type=$WORKLOAD_TYPE ycsb_operation=$YCSB_OPERATION recordcount=$totalrecordcount operationcount=$YCSB_OPERATION_COUNT threads=$THREAD_COUNT target=$TARGET_OPERATIONS_PER_SECOND insertproportion=$INSERT_PROPORTION readproportion=$READ_PROPORTION updateproportion=$UPDATE_PROPORTION scanproportion=$SCAN_PROPORTION diagnosticsLatencyThresholdInMS=$DIAGNOSTICS_LATENCY_THRESHOLD_IN_MS requestdistribution=$REQUEST_DISTRIBUTION sh run.sh
+  uri=$COSMOS_URI primaryKey=$COSMOS_KEY workload_type=$WORKLOAD_TYPE ycsb_operation="run" recordcount=$totalrecordcount operationcount=$YCSB_OPERATION_COUNT threads=$THREAD_COUNT target=$TARGET_OPERATIONS_PER_SECOND insertproportion=$INSERT_PROPORTION readproportion=$READ_PROPORTION updateproportion=$UPDATE_PROPORTION scanproportion=$SCAN_PROPORTION diagnosticsLatencyThresholdInMS=$DIAGNOSTICS_LATENCY_THRESHOLD_IN_MS requestdistribution=$REQUEST_DISTRIBUTION sh run.sh
 fi
 
 #Copy YCSB log to storage account

--- a/execute.sh
+++ b/execute.sh
@@ -70,7 +70,7 @@ if [ $MACHINE_INDEX -eq 1 ]; then
 
   result_storage_url="${protocol}://${account_name}.blob.core.windows.net/result-${current_time}?${sas}"
 
-  client_start_time=$(date -u -d "1 minutes" '+%Y-%m-%dT%H:%M:%S') # date in ISO 8601 format
+  client_start_time=$(date -u -d "5 minutes" '+%Y-%m-%dT%H:%M:%S') # date in ISO 8601 format
   az storage entity insert --entity PartitionKey="ycsb_sql" RowKey="${GUID}" ClientStartTime=$client_start_time SAS_URL=$result_storage_url JobStatus="Started" NoOfClientsCompleted=0 --table-name "${DEPLOYMENT_NAME}Metadata" --connection-string $RESULT_STORAGE_CONNECTION_STRING
 else
   for i in $(seq 1 5); do
@@ -143,7 +143,7 @@ sudo azcopy copy "/home/benchmarking/$VM_NAME-ycsb.log" "$result_storage_url"
 
 if [ $MACHINE_INDEX -eq 1 ]; then
   echo "Waiting on VM1 for 5 min"
-  sleep 5s
+  sleep 5m
   cd /home/benchmarking
   mkdir "aggregation"
   cd aggregation

--- a/execute.sh
+++ b/execute.sh
@@ -97,7 +97,7 @@ fi
 client_start_time=$(date -d "$client_start_time" +'%s')
 
 #Execute YCSB test
-if [ "$WRITE_ONLY_OPERATION" = true ]; then
+if [ "$WRITE_ONLY_OPERATION" = True ] || [ "$WRITE_ONLY_OPERATION" = true ]; then
   now=$(date +"%s")
   wait_interval=$(($client_start_time - $now))
   if [ $wait_interval -gt 0 ]; then

--- a/execute.sh
+++ b/execute.sh
@@ -106,15 +106,15 @@ if [ "$WRITE_ONLY_OPERATION" = True ] || [ "$WRITE_ONLY_OPERATION" = true ]; the
   else
     echo "Not sleeping on clients sync time $client_start_time as it already past"
   fi
-  # Records count for write only ops which start with items count created by Vm(machine_index - 1) client machine from this ops
-  recordcountForWriteOps=$((YCSB_OPERATION_COUNT * (MACHINE_INDEX - 1)))
-  ##execute run phase for YCSB tests with write only workload
+  ## Records count for write only ops which start with items count created by previous(machine_index -1) client machine
+  recordcountForWriteOps=$((YCSB_OPERATION_COUNT * MACHINE_INDEX ))
+  ## Execute run phase for YCSB tests with write only workload
   echo "########## Run operation with write only workload for YCSB tests ###########"
-  uri=$COSMOS_URI primaryKey=$COSMOS_KEY workload_type=$WORKLOAD_TYPE ycsb_operation="run" insertproportion=1 readproportion=0 updateproportion=0 scanproportion=0 recordcount=$recordcountForWriteOps operationcount=$YCSB_OPERATION_COUNT threads=$THREAD_COUNT target=$TARGET_OPERATIONS_PER_SECOND diagnosticsLatencyThresholdInMS=$DIAGNOSTICS_LATENCY_THRESHOLD_IN_MS requestdistribution=$REQUEST_DISTRIBUTION sh run.sh
+  uri=$COSMOS_URI primaryKey=$COSMOS_KEY workload_type=$WORKLOAD_TYPE ycsb_operation="run" insertproportion=1 readproportion=0 updateproportion=0 scanproportion=0 recordcount=$recordcountForWriteOps operationcount=$YCSB_OPERATION_COUNT threads=$THREAD_COUNT target=$TARGET_OPERATIONS_PER_SECOND diagnosticsLatencyThresholdInMS=$DIAGNOSTICS_LATENCY_THRESHOLD_IN_MS requestdistribution=$REQUEST_DISTRIBUTION insertorder=$INSERT_ORDER sh run.sh
 else
-  ##execute load operation for YCSB tests
+  ## Execute load operation for YCSB tests
   echo "########## Load operation for YCSB tests ###########"
-  uri=$COSMOS_URI primaryKey=$COSMOS_KEY workload_type=$WORKLOAD_TYPE ycsb_operation="load" recordcount=$recordcount insertstart=$insertstart insertcount=$YCSB_RECORD_COUNT threads=$THREAD_COUNT target=$TARGET_OPERATIONS_PER_SECOND diagnosticsLatencyThresholdInMS=$DIAGNOSTICS_LATENCY_THRESHOLD_IN_MS requestdistribution=$REQUEST_DISTRIBUTION sh run.sh
+  uri=$COSMOS_URI primaryKey=$COSMOS_KEY workload_type=$WORKLOAD_TYPE ycsb_operation="load" recordcount=$recordcount insertstart=$insertstart insertcount=$YCSB_RECORD_COUNT threads=$THREAD_COUNT target=$TARGET_OPERATIONS_PER_SECOND diagnosticsLatencyThresholdInMS=$DIAGNOSTICS_LATENCY_THRESHOLD_IN_MS requestdistribution=$REQUEST_DISTRIBUTION insertorder=$INSERT_ORDER sh run.sh
 
   now=$(date +"%s")
   wait_interval=$(($client_start_time - $now))
@@ -129,9 +129,9 @@ else
   # Clearing log file from above load operation
   sudo rm -f /tmp/ycsb.log
   sudo rm -f "/home/benchmarking/$VM_NAME-ycsb-load.txt"
-  ##execute run phase for YCSB tests
+  ## Execute run phase for YCSB tests
   echo "########## Run operation for YCSB tests ###########"
-  uri=$COSMOS_URI primaryKey=$COSMOS_KEY workload_type=$WORKLOAD_TYPE ycsb_operation="run" recordcount=$totalrecordcount operationcount=$YCSB_OPERATION_COUNT threads=$THREAD_COUNT target=$TARGET_OPERATIONS_PER_SECOND insertproportion=$INSERT_PROPORTION readproportion=$READ_PROPORTION updateproportion=$UPDATE_PROPORTION scanproportion=$SCAN_PROPORTION diagnosticsLatencyThresholdInMS=$DIAGNOSTICS_LATENCY_THRESHOLD_IN_MS requestdistribution=$REQUEST_DISTRIBUTION sh run.sh
+  uri=$COSMOS_URI primaryKey=$COSMOS_KEY workload_type=$WORKLOAD_TYPE ycsb_operation="run" recordcount=$totalrecordcount operationcount=$YCSB_OPERATION_COUNT threads=$THREAD_COUNT target=$TARGET_OPERATIONS_PER_SECOND insertproportion=$INSERT_PROPORTION readproportion=$READ_PROPORTION updateproportion=$UPDATE_PROPORTION scanproportion=$SCAN_PROPORTION diagnosticsLatencyThresholdInMS=$DIAGNOSTICS_LATENCY_THRESHOLD_IN_MS requestdistribution=$REQUEST_DISTRIBUTION insertorder=$INSERT_ORDER sh run.sh
 fi
 
 #Copy YCSB log to storage account

--- a/execute.sh
+++ b/execute.sh
@@ -105,9 +105,11 @@ if [ "$WRITE_ONLY_OPERATION" = true ]; then
   else
     echo "Not sleeping on clients sync time $client_start_time as it already past"
   fi
+  # Records count for write only ops which start with items count created by Vm(machine_index - 1) client machine from this ops
+  recordcountForWriteOps=$((YCSB_OPERATION_COUNT * (MACHINE_INDEX - 1)))
   ##execute run phase for YCSB tests with write only workload
   echo "########## Run operation with write only workload for YCSB tests ###########"
-  uri=$COSMOS_URI primaryKey=$COSMOS_KEY workload_type=$WORKLOAD_TYPE ycsb_operation="run" insertproportion=1 readproportion=0 updateproportion=0 scanproportion=0 recordcount=$insertstart operationcount=$YCSB_OPERATION_COUNT threads=$THREAD_COUNT target=$TARGET_OPERATIONS_PER_SECOND diagnosticsLatencyThresholdInMS=$DIAGNOSTICS_LATENCY_THRESHOLD_IN_MS requestdistribution=$REQUEST_DISTRIBUTION sh run.sh
+  uri=$COSMOS_URI primaryKey=$COSMOS_KEY workload_type=$WORKLOAD_TYPE ycsb_operation="run" insertproportion=1 readproportion=0 updateproportion=0 scanproportion=0 recordcount=$recordcountForWriteOps operationcount=$YCSB_OPERATION_COUNT threads=$THREAD_COUNT target=$TARGET_OPERATIONS_PER_SECOND diagnosticsLatencyThresholdInMS=$DIAGNOSTICS_LATENCY_THRESHOLD_IN_MS requestdistribution=$REQUEST_DISTRIBUTION sh run.sh
 else
   ##execute load operation for YCSB tests
   echo "########## Load operation for YCSB tests ###########"

--- a/execute.sh
+++ b/execute.sh
@@ -128,7 +128,7 @@ else
   sudo rm -f "/home/benchmarking/$VM_NAME-ycsb-load.txt"
   ##execute run phase for YCSB tests
   echo "########## Run operation for YCSB tests ###########"
-  uri=$COSMOS_URI primaryKey=$COSMOS_KEY workload_type=$WORKLOAD_TYPE ycsb_operation=$YCSB_OPERATION recordcount=$totalrecordcount operationcount=$YCSB_OPERATION_COUNT threads=$THREAD_COUNT target=$TARGET_OPERATIONS_PER_SECOND insertproportion=1 readproportion=0 updateproportion=0 scanproportion=0 diagnosticsLatencyThresholdInMS=$DIAGNOSTICS_LATENCY_THRESHOLD_IN_MS requestdistribution=$REQUEST_DISTRIBUTION sh run.sh
+  uri=$COSMOS_URI primaryKey=$COSMOS_KEY workload_type=$WORKLOAD_TYPE ycsb_operation=$YCSB_OPERATION recordcount=$totalrecordcount operationcount=$YCSB_OPERATION_COUNT threads=$THREAD_COUNT target=$TARGET_OPERATIONS_PER_SECOND insertproportion=$INSERT_PROPORTION readproportion=$READ_PROPORTION updateproportion=$UPDATE_PROPORTION scanproportion=$SCAN_PROPORTION diagnosticsLatencyThresholdInMS=$DIAGNOSTICS_LATENCY_THRESHOLD_IN_MS requestdistribution=$REQUEST_DISTRIBUTION sh run.sh
 fi
 
 #Copy YCSB log to storage account


### PR DESCRIPTION
This PR contains
1. New write only operation flag , now it uses transaction phase and it wont fail on single error , opposite of what it was earlier when write only depend on load phase and single error failing the whole run process
2. Added requestdistribution with default as uniform , it was zipfian earlier which is ycsb's default
3. Added config for insertorder , kept the default in azuredeploy.json as "hashed" same as ycsb, however changed it in dev parameter.json to "ordered"